### PR TITLE
mkdocs.yml: use main branch in edit URI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_name: Zarhus - Your Digital Chess Knight
 site_url: https://docs.zarhus.com
 
 repo_url: https://github.com/zarhus/docs
+edit_uri: blob/main/docs/
 theme:
   name: material
   # custom_dir: overrides


### PR DESCRIPTION
By default it's master which leads to 404 error when pressing source/edit icons ![image](https://github.com/user-attachments/assets/7a588234-4ca9-4710-98dd-d31dda2c2b83)